### PR TITLE
OpenXR fixes

### DIFF
--- a/Source/Core/Common/Matrix.cpp
+++ b/Source/Core/Common/Matrix.cpp
@@ -209,6 +209,35 @@ Matrix44 Matrix44::Translate(const Vec3& vec)
   return mtx;
 }
 
+Matrix44 Matrix44::ForceZ(const float z)
+{
+  Matrix44 mtx = Matrix44::Identity();
+  mtx.data[10] = 0.0f;
+  mtx.data[11] = z;
+  return mtx;
+}
+
+void Matrix44::UseFixedZ(const float z)
+{
+  // Instead of using the incoming z in the matrix,
+  // use the argument.
+  // We accomplish this by moving some z column values into the w column and multiplying.
+  this->data[3] = z * this->data[2];
+  this->data[2] = 0.0f;
+  this->data[7] = z * this->data[6];
+  this->data[6] = 0.0f;
+  this->data[15] = z * this->data[14];
+  this->data[14] = 0.0f;
+  //this->data[15] = -this->data[14]; // Use z=-1 to avoid shrinking
+  //this->data[14] = 0.0f;
+}
+
+void Matrix44::ForceW(const float w)
+{
+  this->data[14] = 0.0f;
+  this->data[15] = w;
+}
+
 Matrix44 Matrix44::Shear(const float a, const float b)
 {
   Matrix44 mtx = Matrix44::Identity();
@@ -242,6 +271,7 @@ Matrix44 Matrix44::Frustum(float left, float right, float bottom, float top, flo
   mtx.data[14] = -1;
   return mtx;
 }
+
 
 void Matrix44::Multiply(const Matrix44& a, const Matrix44& b, Matrix44* result)
 {

--- a/Source/Core/Common/Matrix.cpp
+++ b/Source/Core/Common/Matrix.cpp
@@ -202,6 +202,16 @@ Matrix44 Matrix44::FromArray(const std::array<float, 16>& arr)
   return mtx;
 }
 
+Matrix44 Matrix44::Scale(const Vec3& vec)
+{
+  Matrix44 mtx = {};
+  mtx.data[0] = vec.x;
+  mtx.data[5] = vec.y;
+  mtx.data[10] = vec.z;
+  mtx.data[15] = 1.0f;
+  return mtx;
+}
+
 Matrix44 Matrix44::Translate(const Vec3& vec)
 {
   Matrix44 mtx = Matrix44::Identity();

--- a/Source/Core/Common/Matrix.h
+++ b/Source/Core/Common/Matrix.h
@@ -370,6 +370,8 @@ public:
   static Matrix44 FromMatrix33(const Matrix33& m33);
   static Matrix44 FromArray(const std::array<float, 16>& arr);
 
+  static Matrix44 Scale(const Vec3& vec);
+
   static Matrix44 Translate(const Vec3& vec);
   static Matrix44 ForceZ(const float z);
   void UseFixedZ(const float z);

--- a/Source/Core/Common/Matrix.h
+++ b/Source/Core/Common/Matrix.h
@@ -371,6 +371,9 @@ public:
   static Matrix44 FromArray(const std::array<float, 16>& arr);
 
   static Matrix44 Translate(const Vec3& vec);
+  static Matrix44 ForceZ(const float z);
+  void UseFixedZ(const float z);
+  void ForceW(const float w);
   static Matrix44 Shear(const float a, const float b = 0);
   static Matrix44 Perspective(float fov_y, float aspect_ratio, float z_near, float z_far);
   static Matrix44 Frustum(float left, float right, float bottom, float top, float near, float far);

--- a/Source/Core/Common/Matrix.h
+++ b/Source/Core/Common/Matrix.h
@@ -377,6 +377,7 @@ public:
   static Matrix44 Shear(const float a, const float b = 0);
   static Matrix44 Perspective(float fov_y, float aspect_ratio, float z_near, float z_far);
   static Matrix44 Frustum(float left, float right, float bottom, float top, float near, float far);
+  static Matrix44 FrustumD3D(float left, float right, float bottom, float top, float z_near, float z_far);
 
   static void Multiply(const Matrix44& a, const Matrix44& b, Matrix44* result);
   static void Multiply(const Matrix44& a, const Vec4& vec, Vec4* result);

--- a/Source/Core/Common/OpenXR.cpp
+++ b/Source/Core/Common/OpenXR.cpp
@@ -811,6 +811,11 @@ void Session::ModifyProjectionMatrix(u32 projtype, Common::Matrix44 *proj, int e
   {
     proj->data[7] = -(top + bottom) / height;
   }
+
+  //Matrix44 shiftmatrix = Matrix44::Identity();
+  //shiftmatrix.data[0] = 0.5f;
+  //shiftmatrix.data[3] = eye_index == 0 ? -0.5f : 0.5f;
+  //*proj = shiftmatrix * *proj;
 }
 
 Common::Matrix44 Session::GetTextureShiftMatrix(int eye_index)

--- a/Source/Core/Common/OpenXR.h
+++ b/Source/Core/Common/OpenXR.h
@@ -83,6 +83,8 @@ public:
   // 0:Left, 1:Right
   Common::Matrix44 GetEyeViewMatrix(int eye_index, float near, float far);
 
+  Common::Matrix44 GetHeadMatrix();
+
   Common::Matrix44 GetEyeViewMatrixMove2DObjects(int eye_index, float z_near, float z_far);
 
   Common::Matrix44 GetEyeViewOnlyMatrix(int eye_index);
@@ -134,6 +136,7 @@ private:
   static constexpr uint32_t VIEW_COUNT = 2;
 
   std::array<XrView, VIEW_COUNT> m_eye_views = {};
+  XrSpaceLocation m_view_location = {XR_TYPE_SPACE_LOCATION};
 };
 
 std::unique_ptr<Session> CreateSession(const std::vector<std::string_view>& required_extensions,

--- a/Source/Core/Common/OpenXR.h
+++ b/Source/Core/Common/OpenXR.h
@@ -91,6 +91,9 @@ public:
 
   Common::Matrix44 GetProjectionOnlyMatrix(int eye_index, float z_near, float z_far);
 
+  void GetProjectionBounds(int eye_index, float* angleLeft, float* angleRight, float* angleUp,
+                           float* angleDown);
+
   void ModifyProjectionMatrix(u32 projtype, Common::Matrix44* proj, int eye_index);
 
   Common::Matrix44 GetTextureShiftMatrix(int eye_index);

--- a/Source/Core/Common/OpenXR.h
+++ b/Source/Core/Common/OpenXR.h
@@ -91,9 +91,15 @@ public:
 
   Common::Matrix44 GetProjectionOnlyMatrix(int eye_index, float z_near, float z_far);
 
+  void ModifyProjectionMatrix(u32 projtype, Common::Matrix44* proj, int eye_index);
+
   Common::Matrix44 GetTextureShiftMatrix(int eye_index);
 
   XrSessionState GetState() const;
+
+  void Set3DScreenSize(float width, float height);
+
+  void Set3DScreenZ(float z);
 
 private:
   // Updates predicted display time and eye matrices.
@@ -137,6 +143,10 @@ private:
 
   std::array<XrView, VIEW_COUNT> m_eye_views = {};
   XrSpaceLocation m_view_location = {XR_TYPE_SPACE_LOCATION};
+
+  float m_3d_screen_width;
+  float m_3d_screen_height;
+  float m_3d_screen_z;
 };
 
 std::unique_ptr<Session> CreateSession(const std::vector<std::string_view>& required_extensions,

--- a/Source/Core/Common/OpenXR.h
+++ b/Source/Core/Common/OpenXR.h
@@ -83,6 +83,14 @@ public:
   // 0:Left, 1:Right
   Common::Matrix44 GetEyeViewMatrix(int eye_index, float near, float far);
 
+  Common::Matrix44 GetEyeViewMatrixMove2DObjects(int eye_index, float z_near, float z_far);
+
+  Common::Matrix44 GetEyeViewOnlyMatrix(int eye_index);
+
+  Common::Matrix44 GetProjectionOnlyMatrix(int eye_index, float z_near, float z_far);
+
+  Common::Matrix44 GetTextureShiftMatrix(int eye_index);
+
   XrSessionState GetState() const;
 
 private:
@@ -109,6 +117,7 @@ private:
   XrExtent2Di m_swapchain_size;
 
   XrSpace m_local_space = XR_NULL_HANDLE;
+  XrSpace m_view_space = XR_NULL_HANDLE;
   bool m_is_headless_session = false;
 
   std::atomic<bool> m_run_wait_frame_thread;

--- a/Source/Core/Common/xr_linear.h
+++ b/Source/Core/Common/xr_linear.h
@@ -1,0 +1,787 @@
+// Copyright (c) 2017 The Khronos Group Inc.
+// Copyright (c) 2016 Oculus VR, LLC.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: J.M.P. van Waveren
+//
+
+#ifndef XR_LINEAR_H_
+#define XR_LINEAR_H_
+
+#if defined(OS_LINUX_XCB) || defined(OS_LINUX_XCB_GLX) || defined(OS_LINUX_WAYLAND)
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunused-function"
+#endif
+
+#include <openxr/openxr.h>
+
+/*
+================================================================================================
+
+Description     :       Vector, matrix and quaternion math.
+Author          :       J.M.P. van Waveren
+Date            :       12/10/2016
+Language        :       C99
+Format          :       Indent 4 spaces - no tabs.
+Copyright       :       Copyright (c) 2016 Oculus VR, LLC. All Rights reserved.
+
+
+DESCRIPTION
+===========
+
+All matrices are column-major.
+
+INTERFACE
+=========
+
+XrVector2f
+XrVector3f
+XrVector4f
+XrQuaternionf
+XrMatrix4x4f
+
+inline static void XrVector3f_Set(XrVector3f* v, const float value);
+inline static void XrVector3f_Add(XrVector3f* result, const XrVector3f* a, const XrVector3f* b);
+inline static void XrVector3f_Sub(XrVector3f* result, const XrVector3f* a, const XrVector3f* b);
+inline static void XrVector3f_Min(XrVector3f* result, const XrVector3f* a, const XrVector3f* b);
+inline static void XrVector3f_Max(XrVector3f* result, const XrVector3f* a, const XrVector3f* b);
+inline static void XrVector3f_Decay(XrVector3f* result, const XrVector3f* a, const float value);
+inline static void XrVector3f_Lerp(XrVector3f* result, const XrVector3f* a, const XrVector3f* b, const float fraction);
+inline static void XrVector3f_Scale(XrVector3f* result, const XrVector3f* a, const float scaleFactor);
+inline static void XrVector3f_Normalize(XrVector3f* v);
+inline static float XrVector3f_Length(const XrVector3f* v);
+
+inline static void XrQuaternionf_Lerp(XrQuaternionf* result, const XrQuaternionf* a, const XrQuaternionf* b, const float fraction);
+inline static void XrQuaternionf_Multiply(XrQuaternionf* result, const XrQuaternionf* a, const XrQuaternionf* b;
+
+inline static void XrMatrix4x4f_CreateIdentity(XrMatrix4x4f* result);
+inline static void XrMatrix4x4f_CreateTranslation(XrMatrix4x4f* result, const float x, const float y, const float z);
+inline static void XrMatrix4x4f_CreateRotation(XrMatrix4x4f* result, const float degreesX, const float degreesY,
+                                               const float degreesZ);
+inline static void XrMatrix4x4f_CreateScale(XrMatrix4x4f* result, const float x, const float y, const float z);
+inline static void XrMatrix4x4f_CreateTranslationRotationScale(XrMatrix4x4f* result, const XrVector3f* translation,
+                                                               const XrQuaternionf* rotation, const XrVector3f* scale);
+inline static void XrMatrix4x4f_CreateProjection(XrMatrix4x4f* result, const float tanAngleLeft, const float tanAngleRight,
+                                                 const float tanAngleUp, float const tanAngleDown, const float nearZ,
+                                                 const float farZ);
+inline static void XrMatrix4x4f_CreateProjectionFov(XrMatrix4x4f* result, const float fovDegreesLeft, const float fovDegreesRight,
+                                                    const float fovDegreeUp, const float fovDegreesDown, const float nearZ,
+                                                    const float farZ);
+inline static void XrMatrix4x4f_CreateFromQuaternion(XrMatrix4x4f* result, const XrQuaternionf* src);
+inline static void XrMatrix4x4f_CreateOffsetScaleForBounds(XrMatrix4x4f* result, const XrMatrix4x4f* matrix, const XrVector3f* mins,
+                                                           const XrVector3f* maxs);
+
+inline static bool XrMatrix4x4f_IsAffine(const XrMatrix4x4f* matrix, const float epsilon);
+inline static bool XrMatrix4x4f_IsOrthogonal(const XrMatrix4x4f* matrix, const float epsilon);
+inline static bool XrMatrix4x4f_IsOrthonormal(const XrMatrix4x4f* matrix, const float epsilon);
+inline static bool XrMatrix4x4f_IsRigidBody(const XrMatrix4x4f* matrix, const float epsilon);
+
+inline static void XrMatrix4x4f_GetTranslation(XrVector3f* result, const XrMatrix4x4f* src);
+inline static void XrMatrix4x4f_GetRotation(XrQuaternionf* result, const XrMatrix4x4f* src);
+inline static void XrMatrix4x4f_GetScale(XrVector3f* result, const XrMatrix4x4f* src);
+
+inline static void XrMatrix4x4f_Multiply(XrMatrix4x4f* result, const XrMatrix4x4f* a, const XrMatrix4x4f* b);
+inline static void XrMatrix4x4f_Transpose(XrMatrix4x4f* result, const XrMatrix4x4f* src);
+inline static void XrMatrix4x4f_Invert(XrMatrix4x4f* result, const XrMatrix4x4f* src);
+inline static void XrMatrix4x4f_InvertRigidBody(XrMatrix4x4f* result, const XrMatrix4x4f* src);
+
+inline static void XrMatrix4x4f_TransformVector3f(XrVector3f* result, const XrMatrix4x4f* m, const XrVector3f* v);
+inline static void XrMatrix4x4f_TransformVector4f(XrVector4f* result, const XrMatrix4x4f* m, const XrVector4f* v);
+
+inline static void XrMatrix4x4f_TransformBounds(XrVector3f* resultMins, XrVector3f* resultMaxs, const XrMatrix4x4f* matrix,
+                                                const XrVector3f* mins, const XrVector3f* maxs);
+inline static bool XrMatrix4x4f_CullBounds(const XrMatrix4x4f* mvp, const XrVector3f* mins, const XrVector3f* maxs);
+
+================================================================================================
+*/
+
+#include <assert.h>
+#include <math.h>
+#include <stdbool.h>
+
+#define MATH_PI 3.14159265358979323846f
+
+#define DEFAULT_NEAR_Z 0.015625f  // exact floating point representation
+#define INFINITE_FAR_Z 0.0f
+
+static const XrColor4f XrColorRed = {1.0f, 0.0f, 0.0f, 1.0f};
+static const XrColor4f XrColorGreen = {0.0f, 1.0f, 0.0f, 1.0f};
+static const XrColor4f XrColorBlue = {0.0f, 0.0f, 1.0f, 1.0f};
+static const XrColor4f XrColorYellow = {1.0f, 1.0f, 0.0f, 1.0f};
+static const XrColor4f XrColorPurple = {1.0f, 0.0f, 1.0f, 1.0f};
+static const XrColor4f XrColorCyan = {0.0f, 1.0f, 1.0f, 1.0f};
+static const XrColor4f XrColorLightGrey = {0.7f, 0.7f, 0.7f, 1.0f};
+static const XrColor4f XrColorDarkGrey = {0.3f, 0.3f, 0.3f, 1.0f};
+
+enum GraphicsAPI { GRAPHICS_VULKAN, GRAPHICS_OPENGL, GRAPHICS_OPENGL_ES, GRAPHICS_D3D };
+
+// Column-major, pre-multiplied. This type does not exist in the OpenXR API and is provided for convenience.
+struct XrMatrix4x4f {
+    float m[16];
+};
+
+inline static float XrRcpSqrt(const float x) {
+    const float SMALLEST_NON_DENORMAL = 1.1754943508222875e-038f;  // ( 1U << 23 )
+    const float rcp = (x >= SMALLEST_NON_DENORMAL) ? 1.0f / sqrtf(x) : 1.0f;
+    return rcp;
+}
+
+inline static void XrVector3f_Set(XrVector3f* v, const float value) {
+    v->x = value;
+    v->y = value;
+    v->z = value;
+}
+
+inline static void XrVector3f_Add(XrVector3f* result, const XrVector3f* a, const XrVector3f* b) {
+    result->x = a->x + b->x;
+    result->y = a->y + b->y;
+    result->z = a->z + b->z;
+}
+
+inline static void XrVector3f_Sub(XrVector3f* result, const XrVector3f* a, const XrVector3f* b) {
+    result->x = a->x - b->x;
+    result->y = a->y - b->y;
+    result->z = a->z - b->z;
+}
+
+inline static void XrVector3f_Min(XrVector3f* result, const XrVector3f* a, const XrVector3f* b) {
+    result->x = (a->x < b->x) ? a->x : b->x;
+    result->y = (a->y < b->y) ? a->y : b->y;
+    result->z = (a->z < b->z) ? a->z : b->z;
+}
+
+inline static void XrVector3f_Max(XrVector3f* result, const XrVector3f* a, const XrVector3f* b) {
+    result->x = (a->x > b->x) ? a->x : b->x;
+    result->y = (a->y > b->y) ? a->y : b->y;
+    result->z = (a->z > b->z) ? a->z : b->z;
+}
+
+inline static void XrVector3f_Decay(XrVector3f* result, const XrVector3f* a, const float value) {
+    result->x = (fabsf(a->x) > value) ? ((a->x > 0.0f) ? (a->x - value) : (a->x + value)) : 0.0f;
+    result->y = (fabsf(a->y) > value) ? ((a->y > 0.0f) ? (a->y - value) : (a->y + value)) : 0.0f;
+    result->z = (fabsf(a->z) > value) ? ((a->z > 0.0f) ? (a->z - value) : (a->z + value)) : 0.0f;
+}
+
+inline static void XrVector3f_Lerp(XrVector3f* result, const XrVector3f* a, const XrVector3f* b, const float fraction) {
+    result->x = a->x + fraction * (b->x - a->x);
+    result->y = a->y + fraction * (b->y - a->y);
+    result->z = a->z + fraction * (b->z - a->z);
+}
+
+inline static void XrVector3f_Scale(XrVector3f* result, const XrVector3f* a, const float scaleFactor) {
+    result->x = a->x * scaleFactor;
+    result->y = a->y * scaleFactor;
+    result->z = a->z * scaleFactor;
+}
+
+inline static float XrVector3f_Dot(const XrVector3f* a, const XrVector3f* b) { return a->x * b->x + a->y * b->y + a->z * b->z; }
+
+// Compute cross product, which generates a normal vector.
+// Direction vector can be determined by right-hand rule: Pointing index finder in
+// direction a and middle finger in direction b, thumb will point in Cross(a, b).
+inline static void XrVector3f_Cross(XrVector3f* result, const XrVector3f* a, const XrVector3f* b) {
+    result->x = a->y * b->z - a->z * b->y;
+    result->y = a->z * b->x - a->x * b->z;
+    result->z = a->x * b->y - a->y * b->x;
+}
+
+inline static void XrVector3f_Normalize(XrVector3f* v) {
+    const float lengthRcp = XrRcpSqrt(v->x * v->x + v->y * v->y + v->z * v->z);
+    v->x *= lengthRcp;
+    v->y *= lengthRcp;
+    v->z *= lengthRcp;
+}
+
+inline static float XrVector3f_Length(const XrVector3f* v) { return sqrtf(v->x * v->x + v->y * v->y + v->z * v->z); }
+
+inline static void XrQuaternionf_CreateFromAxisAngle(XrQuaternionf* result, const XrVector3f* axis, const float angleInRadians) {
+    float s = sinf(angleInRadians / 2.0f);
+    float lengthRcp = XrRcpSqrt(axis->x * axis->x + axis->y * axis->y + axis->z * axis->z);
+    result->x = s * axis->x * lengthRcp;
+    result->y = s * axis->y * lengthRcp;
+    result->z = s * axis->z * lengthRcp;
+    result->w = cosf(angleInRadians / 2.0f);
+}
+
+inline static void XrQuaternionf_Lerp(XrQuaternionf* result, const XrQuaternionf* a, const XrQuaternionf* b, const float fraction) {
+    const float s = a->x * b->x + a->y * b->y + a->z * b->z + a->w * b->w;
+    const float fa = 1.0f - fraction;
+    const float fb = (s < 0.0f) ? -fraction : fraction;
+    const float x = a->x * fa + b->x * fb;
+    const float y = a->y * fa + b->y * fb;
+    const float z = a->z * fa + b->z * fb;
+    const float w = a->w * fa + b->w * fb;
+    const float lengthRcp = XrRcpSqrt(x * x + y * y + z * z + w * w);
+    result->x = x * lengthRcp;
+    result->y = y * lengthRcp;
+    result->z = z * lengthRcp;
+    result->w = w * lengthRcp;
+}
+
+inline static void XrQuaternionf_Multiply(XrQuaternionf* result, const XrQuaternionf* a, const XrQuaternionf* b) {
+    result->x = (b->w * a->x) + (b->x * a->w) + (b->y * a->z) - (b->z * a->y);
+    result->y = (b->w * a->y) - (b->x * a->z) + (b->y * a->w) + (b->z * a->x);
+    result->z = (b->w * a->z) + (b->x * a->y) - (b->y * a->x) + (b->z * a->w);
+    result->w = (b->w * a->w) - (b->x * a->x) - (b->y * a->y) - (b->z * a->z);
+}
+
+// Use left-multiplication to accumulate transformations.
+inline static void XrMatrix4x4f_Multiply(XrMatrix4x4f* result, const XrMatrix4x4f* a, const XrMatrix4x4f* b) {
+    result->m[0] = a->m[0] * b->m[0] + a->m[4] * b->m[1] + a->m[8] * b->m[2] + a->m[12] * b->m[3];
+    result->m[1] = a->m[1] * b->m[0] + a->m[5] * b->m[1] + a->m[9] * b->m[2] + a->m[13] * b->m[3];
+    result->m[2] = a->m[2] * b->m[0] + a->m[6] * b->m[1] + a->m[10] * b->m[2] + a->m[14] * b->m[3];
+    result->m[3] = a->m[3] * b->m[0] + a->m[7] * b->m[1] + a->m[11] * b->m[2] + a->m[15] * b->m[3];
+
+    result->m[4] = a->m[0] * b->m[4] + a->m[4] * b->m[5] + a->m[8] * b->m[6] + a->m[12] * b->m[7];
+    result->m[5] = a->m[1] * b->m[4] + a->m[5] * b->m[5] + a->m[9] * b->m[6] + a->m[13] * b->m[7];
+    result->m[6] = a->m[2] * b->m[4] + a->m[6] * b->m[5] + a->m[10] * b->m[6] + a->m[14] * b->m[7];
+    result->m[7] = a->m[3] * b->m[4] + a->m[7] * b->m[5] + a->m[11] * b->m[6] + a->m[15] * b->m[7];
+
+    result->m[8] = a->m[0] * b->m[8] + a->m[4] * b->m[9] + a->m[8] * b->m[10] + a->m[12] * b->m[11];
+    result->m[9] = a->m[1] * b->m[8] + a->m[5] * b->m[9] + a->m[9] * b->m[10] + a->m[13] * b->m[11];
+    result->m[10] = a->m[2] * b->m[8] + a->m[6] * b->m[9] + a->m[10] * b->m[10] + a->m[14] * b->m[11];
+    result->m[11] = a->m[3] * b->m[8] + a->m[7] * b->m[9] + a->m[11] * b->m[10] + a->m[15] * b->m[11];
+
+    result->m[12] = a->m[0] * b->m[12] + a->m[4] * b->m[13] + a->m[8] * b->m[14] + a->m[12] * b->m[15];
+    result->m[13] = a->m[1] * b->m[12] + a->m[5] * b->m[13] + a->m[9] * b->m[14] + a->m[13] * b->m[15];
+    result->m[14] = a->m[2] * b->m[12] + a->m[6] * b->m[13] + a->m[10] * b->m[14] + a->m[14] * b->m[15];
+    result->m[15] = a->m[3] * b->m[12] + a->m[7] * b->m[13] + a->m[11] * b->m[14] + a->m[15] * b->m[15];
+}
+
+// Creates the transpose of the given matrix.
+inline static void XrMatrix4x4f_Transpose(XrMatrix4x4f* result, const XrMatrix4x4f* src) {
+    result->m[0] = src->m[0];
+    result->m[1] = src->m[4];
+    result->m[2] = src->m[8];
+    result->m[3] = src->m[12];
+
+    result->m[4] = src->m[1];
+    result->m[5] = src->m[5];
+    result->m[6] = src->m[9];
+    result->m[7] = src->m[13];
+
+    result->m[8] = src->m[2];
+    result->m[9] = src->m[6];
+    result->m[10] = src->m[10];
+    result->m[11] = src->m[14];
+
+    result->m[12] = src->m[3];
+    result->m[13] = src->m[7];
+    result->m[14] = src->m[11];
+    result->m[15] = src->m[15];
+}
+
+// Returns a 3x3 minor of a 4x4 matrix.
+inline static float XrMatrix4x4f_Minor(const XrMatrix4x4f* matrix, int r0, int r1, int r2, int c0, int c1, int c2) {
+    return matrix->m[4 * r0 + c0] *
+               (matrix->m[4 * r1 + c1] * matrix->m[4 * r2 + c2] - matrix->m[4 * r2 + c1] * matrix->m[4 * r1 + c2]) -
+           matrix->m[4 * r0 + c1] *
+               (matrix->m[4 * r1 + c0] * matrix->m[4 * r2 + c2] - matrix->m[4 * r2 + c0] * matrix->m[4 * r1 + c2]) +
+           matrix->m[4 * r0 + c2] *
+               (matrix->m[4 * r1 + c0] * matrix->m[4 * r2 + c1] - matrix->m[4 * r2 + c0] * matrix->m[4 * r1 + c1]);
+}
+
+// Calculates the inverse of a 4x4 matrix.
+inline static void XrMatrix4x4f_Invert(XrMatrix4x4f* result, const XrMatrix4x4f* src) {
+    const float rcpDet =
+        1.0f / (src->m[0] * XrMatrix4x4f_Minor(src, 1, 2, 3, 1, 2, 3) - src->m[1] * XrMatrix4x4f_Minor(src, 1, 2, 3, 0, 2, 3) +
+                src->m[2] * XrMatrix4x4f_Minor(src, 1, 2, 3, 0, 1, 3) - src->m[3] * XrMatrix4x4f_Minor(src, 1, 2, 3, 0, 1, 2));
+
+    result->m[0] = XrMatrix4x4f_Minor(src, 1, 2, 3, 1, 2, 3) * rcpDet;
+    result->m[1] = -XrMatrix4x4f_Minor(src, 0, 2, 3, 1, 2, 3) * rcpDet;
+    result->m[2] = XrMatrix4x4f_Minor(src, 0, 1, 3, 1, 2, 3) * rcpDet;
+    result->m[3] = -XrMatrix4x4f_Minor(src, 0, 1, 2, 1, 2, 3) * rcpDet;
+    result->m[4] = -XrMatrix4x4f_Minor(src, 1, 2, 3, 0, 2, 3) * rcpDet;
+    result->m[5] = XrMatrix4x4f_Minor(src, 0, 2, 3, 0, 2, 3) * rcpDet;
+    result->m[6] = -XrMatrix4x4f_Minor(src, 0, 1, 3, 0, 2, 3) * rcpDet;
+    result->m[7] = XrMatrix4x4f_Minor(src, 0, 1, 2, 0, 2, 3) * rcpDet;
+    result->m[8] = XrMatrix4x4f_Minor(src, 1, 2, 3, 0, 1, 3) * rcpDet;
+    result->m[9] = -XrMatrix4x4f_Minor(src, 0, 2, 3, 0, 1, 3) * rcpDet;
+    result->m[10] = XrMatrix4x4f_Minor(src, 0, 1, 3, 0, 1, 3) * rcpDet;
+    result->m[11] = -XrMatrix4x4f_Minor(src, 0, 1, 2, 0, 1, 3) * rcpDet;
+    result->m[12] = -XrMatrix4x4f_Minor(src, 1, 2, 3, 0, 1, 2) * rcpDet;
+    result->m[13] = XrMatrix4x4f_Minor(src, 0, 2, 3, 0, 1, 2) * rcpDet;
+    result->m[14] = -XrMatrix4x4f_Minor(src, 0, 1, 3, 0, 1, 2) * rcpDet;
+    result->m[15] = XrMatrix4x4f_Minor(src, 0, 1, 2, 0, 1, 2) * rcpDet;
+}
+
+// Calculates the inverse of a rigid body transform.
+inline static void XrMatrix4x4f_InvertRigidBody(XrMatrix4x4f* result, const XrMatrix4x4f* src) {
+    result->m[0] = src->m[0];
+    result->m[1] = src->m[4];
+    result->m[2] = src->m[8];
+    result->m[3] = 0.0f;
+    result->m[4] = src->m[1];
+    result->m[5] = src->m[5];
+    result->m[6] = src->m[9];
+    result->m[7] = 0.0f;
+    result->m[8] = src->m[2];
+    result->m[9] = src->m[6];
+    result->m[10] = src->m[10];
+    result->m[11] = 0.0f;
+    result->m[12] = -(src->m[0] * src->m[12] + src->m[1] * src->m[13] + src->m[2] * src->m[14]);
+    result->m[13] = -(src->m[4] * src->m[12] + src->m[5] * src->m[13] + src->m[6] * src->m[14]);
+    result->m[14] = -(src->m[8] * src->m[12] + src->m[9] * src->m[13] + src->m[10] * src->m[14]);
+    result->m[15] = 1.0f;
+}
+
+// Creates an identity matrix.
+inline static void XrMatrix4x4f_CreateIdentity(XrMatrix4x4f* result) {
+    result->m[0] = 1.0f;
+    result->m[1] = 0.0f;
+    result->m[2] = 0.0f;
+    result->m[3] = 0.0f;
+    result->m[4] = 0.0f;
+    result->m[5] = 1.0f;
+    result->m[6] = 0.0f;
+    result->m[7] = 0.0f;
+    result->m[8] = 0.0f;
+    result->m[9] = 0.0f;
+    result->m[10] = 1.0f;
+    result->m[11] = 0.0f;
+    result->m[12] = 0.0f;
+    result->m[13] = 0.0f;
+    result->m[14] = 0.0f;
+    result->m[15] = 1.0f;
+}
+
+// Creates a translation matrix.
+inline static void XrMatrix4x4f_CreateTranslation(XrMatrix4x4f* result, const float x, const float y, const float z) {
+    result->m[0] = 1.0f;
+    result->m[1] = 0.0f;
+    result->m[2] = 0.0f;
+    result->m[3] = 0.0f;
+    result->m[4] = 0.0f;
+    result->m[5] = 1.0f;
+    result->m[6] = 0.0f;
+    result->m[7] = 0.0f;
+    result->m[8] = 0.0f;
+    result->m[9] = 0.0f;
+    result->m[10] = 1.0f;
+    result->m[11] = 0.0f;
+    result->m[12] = x;
+    result->m[13] = y;
+    result->m[14] = z;
+    result->m[15] = 1.0f;
+}
+
+// Creates a rotation matrix.
+// If -Z=forward, +Y=up, +X=right, then degreesX=pitch, degreesY=yaw, degreesZ=roll.
+inline static void XrMatrix4x4f_CreateRotation(XrMatrix4x4f* result, const float degreesX, const float degreesY,
+                                               const float degreesZ) {
+    const float sinX = sinf(degreesX * (MATH_PI / 180.0f));
+    const float cosX = cosf(degreesX * (MATH_PI / 180.0f));
+    const XrMatrix4x4f rotationX = {{1, 0, 0, 0, 0, cosX, sinX, 0, 0, -sinX, cosX, 0, 0, 0, 0, 1}};
+    const float sinY = sinf(degreesY * (MATH_PI / 180.0f));
+    const float cosY = cosf(degreesY * (MATH_PI / 180.0f));
+    const XrMatrix4x4f rotationY = {{cosY, 0, -sinY, 0, 0, 1, 0, 0, sinY, 0, cosY, 0, 0, 0, 0, 1}};
+    const float sinZ = sinf(degreesZ * (MATH_PI / 180.0f));
+    const float cosZ = cosf(degreesZ * (MATH_PI / 180.0f));
+    const XrMatrix4x4f rotationZ = {{cosZ, sinZ, 0, 0, -sinZ, cosZ, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}};
+    XrMatrix4x4f rotationXY;
+    XrMatrix4x4f_Multiply(&rotationXY, &rotationY, &rotationX);
+    XrMatrix4x4f_Multiply(result, &rotationZ, &rotationXY);
+}
+
+// Creates a scale matrix.
+inline static void XrMatrix4x4f_CreateScale(XrMatrix4x4f* result, const float x, const float y, const float z) {
+    result->m[0] = x;
+    result->m[1] = 0.0f;
+    result->m[2] = 0.0f;
+    result->m[3] = 0.0f;
+    result->m[4] = 0.0f;
+    result->m[5] = y;
+    result->m[6] = 0.0f;
+    result->m[7] = 0.0f;
+    result->m[8] = 0.0f;
+    result->m[9] = 0.0f;
+    result->m[10] = z;
+    result->m[11] = 0.0f;
+    result->m[12] = 0.0f;
+    result->m[13] = 0.0f;
+    result->m[14] = 0.0f;
+    result->m[15] = 1.0f;
+}
+
+// Creates a matrix from a quaternion.
+inline static void XrMatrix4x4f_CreateFromQuaternion(XrMatrix4x4f* result, const XrQuaternionf* quat) {
+    const float x2 = quat->x + quat->x;
+    const float y2 = quat->y + quat->y;
+    const float z2 = quat->z + quat->z;
+
+    const float xx2 = quat->x * x2;
+    const float yy2 = quat->y * y2;
+    const float zz2 = quat->z * z2;
+
+    const float yz2 = quat->y * z2;
+    const float wx2 = quat->w * x2;
+    const float xy2 = quat->x * y2;
+    const float wz2 = quat->w * z2;
+    const float xz2 = quat->x * z2;
+    const float wy2 = quat->w * y2;
+
+    result->m[0] = 1.0f - yy2 - zz2;
+    result->m[1] = xy2 + wz2;
+    result->m[2] = xz2 - wy2;
+    result->m[3] = 0.0f;
+
+    result->m[4] = xy2 - wz2;
+    result->m[5] = 1.0f - xx2 - zz2;
+    result->m[6] = yz2 + wx2;
+    result->m[7] = 0.0f;
+
+    result->m[8] = xz2 + wy2;
+    result->m[9] = yz2 - wx2;
+    result->m[10] = 1.0f - xx2 - yy2;
+    result->m[11] = 0.0f;
+
+    result->m[12] = 0.0f;
+    result->m[13] = 0.0f;
+    result->m[14] = 0.0f;
+    result->m[15] = 1.0f;
+}
+
+// Creates a combined translation(rotation(scale(object))) matrix.
+inline static void XrMatrix4x4f_CreateTranslationRotationScale(XrMatrix4x4f* result, const XrVector3f* translation,
+                                                               const XrQuaternionf* rotation, const XrVector3f* scale) {
+    XrMatrix4x4f scaleMatrix;
+    XrMatrix4x4f_CreateScale(&scaleMatrix, scale->x, scale->y, scale->z);
+
+    XrMatrix4x4f rotationMatrix;
+    XrMatrix4x4f_CreateFromQuaternion(&rotationMatrix, rotation);
+
+    XrMatrix4x4f translationMatrix;
+    XrMatrix4x4f_CreateTranslation(&translationMatrix, translation->x, translation->y, translation->z);
+
+    XrMatrix4x4f combinedMatrix;
+    XrMatrix4x4f_Multiply(&combinedMatrix, &rotationMatrix, &scaleMatrix);
+    XrMatrix4x4f_Multiply(result, &translationMatrix, &combinedMatrix);
+}
+
+// Creates a projection matrix based on the specified dimensions.
+// The projection matrix transforms -Z=forward, +Y=up, +X=right to the appropriate clip space for the graphics API.
+// The far plane is placed at infinity if farZ <= nearZ.
+// An infinite projection matrix is preferred for rasterization because, except for
+// things *right* up against the near plane, it always provides better precision:
+//              "Tightening the Precision of Perspective Rendering"
+//              Paul Upchurch, Mathieu Desbrun
+//              Journal of Graphics Tools, Volume 16, Issue 1, 2012
+inline static void XrMatrix4x4f_CreateProjection(XrMatrix4x4f* result, GraphicsAPI graphicsApi, const float tanAngleLeft,
+                                                 const float tanAngleRight, const float tanAngleUp, float const tanAngleDown,
+                                                 const float nearZ, const float farZ) {
+    const float tanAngleWidth = tanAngleRight - tanAngleLeft;
+
+    // Set to tanAngleDown - tanAngleUp for a clip space with positive Y down (Vulkan).
+    // Set to tanAngleUp - tanAngleDown for a clip space with positive Y up (OpenGL / D3D / Metal).
+    const float tanAngleHeight = graphicsApi == GRAPHICS_VULKAN ? (tanAngleDown - tanAngleUp) : (tanAngleUp - tanAngleDown);
+
+    // Set to nearZ for a [-1,1] Z clip space (OpenGL / OpenGL ES).
+    // Set to zero for a [0,1] Z clip space (Vulkan / D3D / Metal).
+    const float offsetZ = (graphicsApi == GRAPHICS_OPENGL || graphicsApi == GRAPHICS_OPENGL_ES) ? nearZ : 0;
+
+    if (farZ <= nearZ) {
+        // place the far plane at infinity
+        result->m[0] = 2.0f / tanAngleWidth;
+        result->m[4] = 0.0f;
+        result->m[8] = (tanAngleRight + tanAngleLeft) / tanAngleWidth;
+        result->m[12] = 0.0f;
+
+        result->m[1] = 0.0f;
+        result->m[5] = 2.0f / tanAngleHeight;
+        result->m[9] = (tanAngleUp + tanAngleDown) / tanAngleHeight;
+        result->m[13] = 0.0f;
+
+        result->m[2] = 0.0f;
+        result->m[6] = 0.0f;
+        result->m[10] = -1.0f;
+        result->m[14] = -(nearZ + offsetZ);
+
+        result->m[3] = 0.0f;
+        result->m[7] = 0.0f;
+        result->m[11] = -1.0f;
+        result->m[15] = 0.0f;
+    } else {
+        // normal projection
+        result->m[0] = 2.0f / tanAngleWidth;
+        result->m[4] = 0.0f;
+        result->m[8] = (tanAngleRight + tanAngleLeft) / tanAngleWidth;
+        result->m[12] = 0.0f;
+
+        result->m[1] = 0.0f;
+        result->m[5] = 2.0f / tanAngleHeight;
+        result->m[9] = (tanAngleUp + tanAngleDown) / tanAngleHeight;
+        result->m[13] = 0.0f;
+
+        result->m[2] = 0.0f;
+        result->m[6] = 0.0f;
+        result->m[10] = -(farZ + offsetZ) / (farZ - nearZ);
+        result->m[14] = -(farZ * (nearZ + offsetZ)) / (farZ - nearZ);
+
+        result->m[3] = 0.0f;
+        result->m[7] = 0.0f;
+        result->m[11] = -1.0f;
+        result->m[15] = 0.0f;
+    }
+}
+
+// Creates a projection matrix based on the specified FOV.
+inline static void XrMatrix4x4f_CreateProjectionFov(XrMatrix4x4f* result, GraphicsAPI graphicsApi, const XrFovf fov,
+                                                    const float nearZ, const float farZ) {
+    const float tanLeft = tanf(fov.angleLeft);
+    const float tanRight = tanf(fov.angleRight);
+
+    const float tanDown = tanf(fov.angleDown);
+    const float tanUp = tanf(fov.angleUp);
+
+    XrMatrix4x4f_CreateProjection(result, graphicsApi, tanLeft, tanRight, tanUp, tanDown, nearZ, farZ);
+}
+
+// Creates a matrix that transforms the -1 to 1 cube to cover the given 'mins' and 'maxs' transformed with the given 'matrix'.
+inline static void XrMatrix4x4f_CreateOffsetScaleForBounds(XrMatrix4x4f* result, const XrMatrix4x4f* matrix, const XrVector3f* mins,
+                                                           const XrVector3f* maxs) {
+    const XrVector3f offset = {(maxs->x + mins->x) * 0.5f, (maxs->y + mins->y) * 0.5f, (maxs->z + mins->z) * 0.5f};
+    const XrVector3f scale = {(maxs->x - mins->x) * 0.5f, (maxs->y - mins->y) * 0.5f, (maxs->z - mins->z) * 0.5f};
+
+    result->m[0] = matrix->m[0] * scale.x;
+    result->m[1] = matrix->m[1] * scale.x;
+    result->m[2] = matrix->m[2] * scale.x;
+    result->m[3] = matrix->m[3] * scale.x;
+
+    result->m[4] = matrix->m[4] * scale.y;
+    result->m[5] = matrix->m[5] * scale.y;
+    result->m[6] = matrix->m[6] * scale.y;
+    result->m[7] = matrix->m[7] * scale.y;
+
+    result->m[8] = matrix->m[8] * scale.z;
+    result->m[9] = matrix->m[9] * scale.z;
+    result->m[10] = matrix->m[10] * scale.z;
+    result->m[11] = matrix->m[11] * scale.z;
+
+    result->m[12] = matrix->m[12] + matrix->m[0] * offset.x + matrix->m[4] * offset.y + matrix->m[8] * offset.z;
+    result->m[13] = matrix->m[13] + matrix->m[1] * offset.x + matrix->m[5] * offset.y + matrix->m[9] * offset.z;
+    result->m[14] = matrix->m[14] + matrix->m[2] * offset.x + matrix->m[6] * offset.y + matrix->m[10] * offset.z;
+    result->m[15] = matrix->m[15] + matrix->m[3] * offset.x + matrix->m[7] * offset.y + matrix->m[11] * offset.z;
+}
+
+// Returns true if the given matrix is affine.
+inline static bool XrMatrix4x4f_IsAffine(const XrMatrix4x4f* matrix, const float epsilon) {
+    return fabsf(matrix->m[3]) <= epsilon && fabsf(matrix->m[7]) <= epsilon && fabsf(matrix->m[11]) <= epsilon &&
+           fabsf(matrix->m[15] - 1.0f) <= epsilon;
+}
+
+// Returns true if the given matrix is orthogonal.
+inline static bool XrMatrix4x4f_IsOrthogonal(const XrMatrix4x4f* matrix, const float epsilon) {
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            if (i != j) {
+                if (fabsf(matrix->m[4 * i + 0] * matrix->m[4 * j + 0] + matrix->m[4 * i + 1] * matrix->m[4 * j + 1] +
+                          matrix->m[4 * i + 2] * matrix->m[4 * j + 2]) > epsilon) {
+                    return false;
+                }
+                if (fabsf(matrix->m[4 * 0 + i] * matrix->m[4 * 0 + j] + matrix->m[4 * 1 + i] * matrix->m[4 * 1 + j] +
+                          matrix->m[4 * 2 + i] * matrix->m[4 * 2 + j]) > epsilon) {
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+// Returns true if the given matrix is orthonormal.
+inline static bool XrMatrix4x4f_IsOrthonormal(const XrMatrix4x4f* matrix, const float epsilon) {
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            const float kd = (i == j) ? 1.0f : 0.0f;  // Kronecker delta
+            if (fabsf(kd - (matrix->m[4 * i + 0] * matrix->m[4 * j + 0] + matrix->m[4 * i + 1] * matrix->m[4 * j + 1] +
+                            matrix->m[4 * i + 2] * matrix->m[4 * j + 2])) > epsilon) {
+                return false;
+            }
+            if (fabsf(kd - (matrix->m[4 * 0 + i] * matrix->m[4 * 0 + j] + matrix->m[4 * 1 + i] * matrix->m[4 * 1 + j] +
+                            matrix->m[4 * 2 + i] * matrix->m[4 * 2 + j])) > epsilon) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+// Returns true if the given matrix is a rigid body transform.
+inline static bool XrMatrix4x4f_IsRigidBody(const XrMatrix4x4f* matrix, const float epsilon) {
+    return XrMatrix4x4f_IsAffine(matrix, epsilon) && XrMatrix4x4f_IsOrthonormal(matrix, epsilon);
+}
+
+// Get the translation from a combined translation(rotation(scale(object))) matrix.
+inline static void XrMatrix4x4f_GetTranslation(XrVector3f* result, const XrMatrix4x4f* src) {
+    assert(XrMatrix4x4f_IsAffine(src, 1e-4f));
+    assert(XrMatrix4x4f_IsOrthogonal(src, 1e-4f));
+
+    result->x = src->m[12];
+    result->y = src->m[13];
+    result->z = src->m[14];
+}
+
+// Get the rotation from a combined translation(rotation(scale(object))) matrix.
+inline static void XrMatrix4x4f_GetRotation(XrQuaternionf* result, const XrMatrix4x4f* src) {
+    assert(XrMatrix4x4f_IsAffine(src, 1e-4f));
+    assert(XrMatrix4x4f_IsOrthogonal(src, 1e-4f));
+
+    const float rcpScaleX = XrRcpSqrt(src->m[0] * src->m[0] + src->m[1] * src->m[1] + src->m[2] * src->m[2]);
+    const float rcpScaleY = XrRcpSqrt(src->m[4] * src->m[4] + src->m[5] * src->m[5] + src->m[6] * src->m[6]);
+    const float rcpScaleZ = XrRcpSqrt(src->m[8] * src->m[8] + src->m[9] * src->m[9] + src->m[10] * src->m[10]);
+    const float m[9] = {src->m[0] * rcpScaleX, src->m[1] * rcpScaleX, src->m[2] * rcpScaleX,
+                        src->m[4] * rcpScaleY, src->m[5] * rcpScaleY, src->m[6] * rcpScaleY,
+                        src->m[8] * rcpScaleZ, src->m[9] * rcpScaleZ, src->m[10] * rcpScaleZ};
+    if (m[0 * 3 + 0] + m[1 * 3 + 1] + m[2 * 3 + 2] > 0.0f) {
+        float t = +m[0 * 3 + 0] + m[1 * 3 + 1] + m[2 * 3 + 2] + 1.0f;
+        float s = XrRcpSqrt(t) * 0.5f;
+        result->w = s * t;
+        result->z = (m[0 * 3 + 1] - m[1 * 3 + 0]) * s;
+        result->y = (m[2 * 3 + 0] - m[0 * 3 + 2]) * s;
+        result->x = (m[1 * 3 + 2] - m[2 * 3 + 1]) * s;
+    } else if (m[0 * 3 + 0] > m[1 * 3 + 1] && m[0 * 3 + 0] > m[2 * 3 + 2]) {
+        float t = +m[0 * 3 + 0] - m[1 * 3 + 1] - m[2 * 3 + 2] + 1.0f;
+        float s = XrRcpSqrt(t) * 0.5f;
+        result->x = s * t;
+        result->y = (m[0 * 3 + 1] + m[1 * 3 + 0]) * s;
+        result->z = (m[2 * 3 + 0] + m[0 * 3 + 2]) * s;
+        result->w = (m[1 * 3 + 2] - m[2 * 3 + 1]) * s;
+    } else if (m[1 * 3 + 1] > m[2 * 3 + 2]) {
+        float t = -m[0 * 3 + 0] + m[1 * 3 + 1] - m[2 * 3 + 2] + 1.0f;
+        float s = XrRcpSqrt(t) * 0.5f;
+        result->y = s * t;
+        result->x = (m[0 * 3 + 1] + m[1 * 3 + 0]) * s;
+        result->w = (m[2 * 3 + 0] - m[0 * 3 + 2]) * s;
+        result->z = (m[1 * 3 + 2] + m[2 * 3 + 1]) * s;
+    } else {
+        float t = -m[0 * 3 + 0] - m[1 * 3 + 1] + m[2 * 3 + 2] + 1.0f;
+        float s = XrRcpSqrt(t) * 0.5f;
+        result->z = s * t;
+        result->w = (m[0 * 3 + 1] - m[1 * 3 + 0]) * s;
+        result->x = (m[2 * 3 + 0] + m[0 * 3 + 2]) * s;
+        result->y = (m[1 * 3 + 2] + m[2 * 3 + 1]) * s;
+    }
+}
+
+// Get the scale from a combined translation(rotation(scale(object))) matrix.
+inline static void XrMatrix4x4f_GetScale(XrVector3f* result, const XrMatrix4x4f* src) {
+    assert(XrMatrix4x4f_IsAffine(src, 1e-4f));
+    assert(XrMatrix4x4f_IsOrthogonal(src, 1e-4f));
+
+    result->x = sqrtf(src->m[0] * src->m[0] + src->m[1] * src->m[1] + src->m[2] * src->m[2]);
+    result->y = sqrtf(src->m[4] * src->m[4] + src->m[5] * src->m[5] + src->m[6] * src->m[6]);
+    result->z = sqrtf(src->m[8] * src->m[8] + src->m[9] * src->m[9] + src->m[10] * src->m[10]);
+}
+
+// Transforms a 3D vector.
+inline static void XrMatrix4x4f_TransformVector3f(XrVector3f* result, const XrMatrix4x4f* m, const XrVector3f* v) {
+    const float w = m->m[3] * v->x + m->m[7] * v->y + m->m[11] * v->z + m->m[15];
+    const float rcpW = 1.0f / w;
+    result->x = (m->m[0] * v->x + m->m[4] * v->y + m->m[8] * v->z + m->m[12]) * rcpW;
+    result->y = (m->m[1] * v->x + m->m[5] * v->y + m->m[9] * v->z + m->m[13]) * rcpW;
+    result->z = (m->m[2] * v->x + m->m[6] * v->y + m->m[10] * v->z + m->m[14]) * rcpW;
+}
+
+// Transforms a 4D vector.
+inline static void XrMatrix4x4f_TransformVector4f(XrVector4f* result, const XrMatrix4x4f* m, const XrVector4f* v) {
+    result->x = m->m[0] * v->x + m->m[4] * v->y + m->m[8] * v->z + m->m[12] * v->w;
+    result->y = m->m[1] * v->x + m->m[5] * v->y + m->m[9] * v->z + m->m[13] * v->w;
+    result->z = m->m[2] * v->x + m->m[6] * v->y + m->m[10] * v->z + m->m[14] * v->w;
+    result->w = m->m[3] * v->x + m->m[7] * v->y + m->m[11] * v->z + m->m[15] * v->w;
+}
+
+// Transforms the 'mins' and 'maxs' bounds with the given 'matrix'.
+inline static void XrMatrix4x4f_TransformBounds(XrVector3f* resultMins, XrVector3f* resultMaxs, const XrMatrix4x4f* matrix,
+                                                const XrVector3f* mins, const XrVector3f* maxs) {
+    assert(XrMatrix4x4f_IsAffine(matrix, 1e-4f));
+
+    const XrVector3f center = {(mins->x + maxs->x) * 0.5f, (mins->y + maxs->y) * 0.5f, (mins->z + maxs->z) * 0.5f};
+    const XrVector3f extents = {maxs->x - center.x, maxs->y - center.y, maxs->z - center.z};
+    const XrVector3f newCenter = {matrix->m[0] * center.x + matrix->m[4] * center.y + matrix->m[8] * center.z + matrix->m[12],
+                                  matrix->m[1] * center.x + matrix->m[5] * center.y + matrix->m[9] * center.z + matrix->m[13],
+                                  matrix->m[2] * center.x + matrix->m[6] * center.y + matrix->m[10] * center.z + matrix->m[14]};
+    const XrVector3f newExtents = {
+        fabsf(extents.x * matrix->m[0]) + fabsf(extents.y * matrix->m[4]) + fabsf(extents.z * matrix->m[8]),
+        fabsf(extents.x * matrix->m[1]) + fabsf(extents.y * matrix->m[5]) + fabsf(extents.z * matrix->m[9]),
+        fabsf(extents.x * matrix->m[2]) + fabsf(extents.y * matrix->m[6]) + fabsf(extents.z * matrix->m[10])};
+    XrVector3f_Sub(resultMins, &newCenter, &newExtents);
+    XrVector3f_Add(resultMaxs, &newCenter, &newExtents);
+}
+
+// Returns true if the 'mins' and 'maxs' bounds is completely off to one side of the projection matrix.
+inline static bool XrMatrix4x4f_CullBounds(const XrMatrix4x4f* mvp, const XrVector3f* mins, const XrVector3f* maxs) {
+    if (maxs->x <= mins->x && maxs->y <= mins->y && maxs->z <= mins->z) {
+        return false;
+    }
+
+    XrVector4f c[8];
+    for (int i = 0; i < 8; i++) {
+        const XrVector4f corner = {(i & 1) != 0 ? maxs->x : mins->x, (i & 2) != 0 ? maxs->y : mins->y,
+                                   (i & 4) != 0 ? maxs->z : mins->z, 1.0f};
+        XrMatrix4x4f_TransformVector4f(&c[i], mvp, &corner);
+    }
+
+    int i;
+    for (i = 0; i < 8; i++) {
+        if (c[i].x > -c[i].w) {
+            break;
+        }
+    }
+    if (i == 8) {
+        return true;
+    }
+    for (i = 0; i < 8; i++) {
+        if (c[i].x < c[i].w) {
+            break;
+        }
+    }
+    if (i == 8) {
+        return true;
+    }
+
+    for (i = 0; i < 8; i++) {
+        if (c[i].y > -c[i].w) {
+            break;
+        }
+    }
+    if (i == 8) {
+        return true;
+    }
+    for (i = 0; i < 8; i++) {
+        if (c[i].y < c[i].w) {
+            break;
+        }
+    }
+    if (i == 8) {
+        return true;
+    }
+    for (i = 0; i < 8; i++) {
+        if (c[i].z > -c[i].w) {
+            break;
+        }
+    }
+    if (i == 8) {
+        return true;
+    }
+    for (i = 0; i < 8; i++) {
+        if (c[i].z < c[i].w) {
+            break;
+        }
+    }
+    return i == 8;
+}
+
+#endif  // XR_LINEAR_H_

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -145,13 +145,27 @@ void Renderer::SetViewport(float x, float y, float width, float height, float ne
 void Renderer::Draw(u32 base_vertex, u32 num_vertices)
 {
   D3D::stateman->Apply();
-  D3D::context->Draw(num_vertices, base_vertex);
+  if (g_ActiveConfig.stereo_mode == StereoMode::OpenXR)
+  {
+    D3D::context->DrawInstanced(num_vertices, 2, base_vertex, 0);
+  }
+  else
+  {
+    D3D::context->Draw(num_vertices, base_vertex);
+  }
 }
 
 void Renderer::DrawIndexed(u32 base_index, u32 num_indices, u32 base_vertex)
 {
   D3D::stateman->Apply();
-  D3D::context->DrawIndexed(num_indices, base_index, base_vertex);
+  if (g_ActiveConfig.stereo_mode == StereoMode::OpenXR)
+  {
+    D3D::context->DrawIndexedInstanced(num_indices, 2, base_index, base_vertex, 0);
+  }
+  else
+  {
+    D3D::context->DrawIndexed(num_indices, base_index, base_vertex);
+  }
 }
 
 void Renderer::DispatchComputeShader(const AbstractShader* shader, u32 groups_x, u32 groups_y,

--- a/Source/Core/VideoCommon/ConstantManager.h
+++ b/Source/Core/VideoCommon/ConstantManager.h
@@ -63,6 +63,7 @@ struct VertexShaderConstants
 
   std::array<float4, 6> posnormalmatrix;
   std::array<float4, 4> projection;
+  std::array<float, 4> projection_right;
   std::array<int4, 4> materials;
   struct Light
   {

--- a/Source/Core/VideoCommon/ConstantManager.h
+++ b/Source/Core/VideoCommon/ConstantManager.h
@@ -63,7 +63,7 @@ struct VertexShaderConstants
 
   std::array<float4, 6> posnormalmatrix;
   std::array<float4, 4> projection;
-  std::array<float, 4> projection_right;
+  std::array<float4, 4> projection_right;
   std::array<int4, 4> materials;
   struct Light
   {

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -227,6 +227,9 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
     out.Write("\tVS_OUTPUT f = o[i];\n");
   }
 
+  if (instanced_stereo)
+    out.Write("\tps.layer = o.rendertargetarrayindex;\n");
+
   if (stereo && !instanced_stereo)
   {
     // Select the output layer

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -51,6 +51,7 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
   const bool msaa = host_config.msaa;
   const bool ssaa = host_config.ssaa;
   const bool stereo = host_config.stereo;
+  const bool instanced_stereo = host_config.instanced_stereo;
   const PrimitiveType primitive_type = static_cast<PrimitiveType>(uid_data->primitive_type);
   const unsigned primitive_type_index = static_cast<unsigned>(uid_data->primitive_type);
   const unsigned vertex_in = std::min(static_cast<unsigned>(primitive_type_index) + 1, 3u);
@@ -192,7 +193,7 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
               ".x, -" I_LINEPTPARAMS ".w / " I_LINEPTPARAMS ".y) * center.pos.w;\n");
   }
 
-  if (stereo)
+  if (stereo && !instanced_stereo)
   {
     // If the GPU supports invocation we don't need a for loop and can simply use the
     // invocation identifier to determine which layer we're rendering.
@@ -226,7 +227,7 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
     out.Write("\tVS_OUTPUT f = o[i];\n");
   }
 
-  if (stereo)
+  if (stereo && !instanced_stereo)
   {
     // Select the output layer
     out.Write("\tps.layer = eye;\n");
@@ -309,7 +310,7 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
 
   EndPrimitive(out, host_config, uid_data, ApiType, wireframe);
 
-  if (stereo && !host_config.backend_gs_instancing)
+  if (stereo && !instanced_stereo && !host_config.backend_gs_instancing)
     out.Write("\t}\n");
 
   out.Write("}\n");

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -19,7 +19,7 @@ constexpr std::array<const char*, 4> primitives_d3d = {{"point", "line", "triang
 
 bool geometry_shader_uid_data::IsPassthrough() const
 {
-  const bool stereo = g_ActiveConfig.stereo_mode != StereoMode::Off;
+  const bool stereo = g_ActiveConfig.stereo_mode != StereoMode::Off && g_ActiveConfig.stereo_mode != StereoMode::OpenXR;
   const bool wireframe = g_ActiveConfig.bWireFrame;
   return primitive_type >= static_cast<u32>(PrimitiveType::Triangles) && !stereo && !wireframe;
 }

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -64,6 +64,7 @@ void GeometryShaderManager::SetConstants()
 
         // We must "undo" the game's projection before applying our eye projections.
         const auto inv_projection = projection.Inverted();
+        //const auto inv_head_matrix = openxr_session->GetHeadMatrix().Inverted();
 
         // Use the game's near and far values.
         const float z_near = projection.data[11] / (projection.data[10] - 1);
@@ -77,8 +78,11 @@ void GeometryShaderManager::SetConstants()
         for (auto& eye_view : constants.eye_views)
         {
           if (xfmem.projection.type == GX_PERSPECTIVE)
-            eye_view = openxr_session->GetEyeViewMatrix(eye_index, z_near, z_far) * inv_projection;
-            ///eye_view = projection * openxr_session->GetEyeViewOnlyMatrix(eye_index) * inv_projection;
+            eye_view = openxr_session->GetEyeViewMatrix(eye_index, z_near, z_far) *
+            inv_projection;
+            //eye_view = projection * openxr_session->GetEyeViewOnlyMatrix(eye_index) *
+            //inv_projection;
+            //eye_view = Common::Matrix44::Identity();
           else
           {
             // eye_view =  openxr_session->GetEyeViewOnlyMatrix(eye_index);

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -44,7 +44,7 @@ void GeometryShaderManager::Dirty()
 
 void GeometryShaderManager::SetConstants()
 {
-  if (s_projection_changed && g_ActiveConfig.stereo_mode != StereoMode::Off)
+  if (s_projection_changed && g_ActiveConfig.stereo_mode != StereoMode::Off && g_ActiveConfig.stereo_mode != StereoMode::OpenXR)
   {
     s_projection_changed = false;
 

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -49,8 +49,11 @@ void GeometryShaderManager::SetConstants()
     s_projection_changed = false;
 
     constants.stereoparams.fill(0);
-
-    if (true || xfmem.projection.type == GX_PERSPECTIVE)
+#if USE_OPENXR
+    if (g_renderer->GetOpenXRSession() || xfmem.projection.type == GX_PERSPECTIVE)
+#else
+    if (xfmem.projection.type == GX_PERSPECTIVE)
+#endif
     {
 #if USE_OPENXR
       if (auto* const openxr_session = g_renderer->GetOpenXRSession())

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -64,11 +64,12 @@ void GeometryShaderManager::SetConstants()
 
         // We must "undo" the game's projection before applying our eye projections.
         const auto inv_projection = projection.Inverted();
+        
         //const auto inv_head_matrix = openxr_session->GetHeadMatrix().Inverted();
 
         // Use the game's near and far values.
         const float z_near = projection.data[11] / (projection.data[10] - 1);
-       float z_far = projection.data[11] / (projection.data[10] + 1);
+        //float z_far = projection.data[11] / (projection.data[10] + 1);
 
 
         // GX_ORTHOGRAPHIC projection matrices have an infinity far plane.
@@ -77,12 +78,12 @@ void GeometryShaderManager::SetConstants()
         int eye_index = 0;
         for (auto& eye_view : constants.eye_views)
         {
+          //openxr_session->ModifyProjectionMatrix(xfmem.projection.type, &projection, eye_index);
           if (xfmem.projection.type == GX_PERSPECTIVE)
-            eye_view = openxr_session->GetEyeViewMatrix(eye_index, z_near, z_far) *
-            inv_projection;
-            //eye_view = projection * openxr_session->GetEyeViewOnlyMatrix(eye_index) *
-            //inv_projection;
+            //eye_view = openxr_session->GetEyeViewMatrix(eye_index, z_near, z_far) * inv_projection;
+            eye_view = projection * inv_projection;
             //eye_view = Common::Matrix44::Identity();
+            //eye_view = openxr_session->GetTextureShiftMatrix(eye_index);
           else
           {
             // eye_view =  openxr_session->GetEyeViewOnlyMatrix(eye_index);
@@ -91,11 +92,15 @@ void GeometryShaderManager::SetConstants()
             // eye_view = Common::Matrix44::Identity();
             //auto eye_view_matrix = openxr_session->GetTextureShiftMatrix(eye_index);
             auto eye_view_matrix =
-                openxr_session->GetProjectionOnlyMatrix(eye_index, z_near, 1000.0f);
+                openxr_session->GetProjectionOnlyMatrix(eye_index, z_near, -INFINITY);
             eye_view_matrix.UseFixedZ(-1.0f);
             eye_view = eye_view_matrix;
-            //eye_view = Common::Matrix44::Identity();
+            //eye_view = openxr_session->GetTextureShiftMatrix(eye_index);
+            eye_view = Common::Matrix44::Identity();
+            //constants.stereoparams[2] = -openxr_session->GetTextureShiftMatrix(eye_index).data[3];
+            //eye_view = projection * inv_projection;
           }
+          //eye_view = Common::Matrix44::Identity();
 
           ++eye_index;
         }

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -538,7 +538,7 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const ShaderHostConfig& host
   const bool per_pixel_lighting = g_ActiveConfig.bEnablePixelLighting;
   const bool msaa = host_config.msaa;
   const bool ssaa = host_config.ssaa;
-  const bool stereo = host_config.stereo;
+  const bool stereo = host_config.stereo || host_config.instanced_stereo;
   const u32 numStages = uid_data->genMode_numtevstages + 1;
 
   out.Write("//Pixel Shader for TEV stages\n");

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1403,7 +1403,8 @@ void Renderer::RenderXFBToScreen(const MathUtil::Rectangle<int>& target_rc,
                                  const MathUtil::Rectangle<int>& source_rc)
 {
   if (g_ActiveConfig.stereo_mode == StereoMode::SBS ||
-      g_ActiveConfig.stereo_mode == StereoMode::TAB)
+      g_ActiveConfig.stereo_mode == StereoMode::TAB ||
+      g_ActiveConfig.stereo_mode == StereoMode::OpenXR)
   {
     const auto [left_rc, right_rc] = ConvertStereoRectangle(target_rc);
 

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -17,7 +17,7 @@ ShaderHostConfig ShaderHostConfig::GetCurrent()
   bits.msaa = g_ActiveConfig.iMultisamples > 1;
   bits.ssaa = g_ActiveConfig.iMultisamples > 1 && g_ActiveConfig.bSSAA &&
               g_ActiveConfig.backend_info.bSupportsSSAA;
-  bits.stereo = g_ActiveConfig.stereo_mode != StereoMode::Off;
+  bits.stereo = g_ActiveConfig.stereo_mode != StereoMode::Off && g_ActiveConfig.stereo_mode != StereoMode::OpenXR;
   bits.wireframe = g_ActiveConfig.bWireFrame;
   bits.per_pixel_lighting = g_ActiveConfig.bEnablePixelLighting;
   bits.vertex_rounding = g_ActiveConfig.UseVertexRounding();
@@ -39,6 +39,7 @@ ShaderHostConfig ShaderHostConfig::GetCurrent()
   bits.backend_shader_framebuffer_fetch = g_ActiveConfig.backend_info.bSupportsFramebufferFetch;
   bits.backend_logic_op = g_ActiveConfig.backend_info.bSupportsLogicOp;
   bits.backend_palette_conversion = g_ActiveConfig.backend_info.bSupportsPaletteConversion;
+  bits.instanced_stereo = g_ActiveConfig.stereo_mode == StereoMode::OpenXR;
   return bits;
 }
 

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -17,7 +17,7 @@ ShaderHostConfig ShaderHostConfig::GetCurrent()
   bits.msaa = g_ActiveConfig.iMultisamples > 1;
   bits.ssaa = g_ActiveConfig.iMultisamples > 1 && g_ActiveConfig.bSSAA &&
               g_ActiveConfig.backend_info.bSupportsSSAA;
-  bits.stereo = g_ActiveConfig.stereo_mode != StereoMode::Off && g_ActiveConfig.stereo_mode != StereoMode::OpenXR;
+  bits.stereo = g_ActiveConfig.stereo_mode != StereoMode::Off;
   bits.wireframe = g_ActiveConfig.bWireFrame;
   bits.per_pixel_lighting = g_ActiveConfig.bEnablePixelLighting;
   bits.vertex_rounding = g_ActiveConfig.UseVertexRounding();
@@ -134,6 +134,11 @@ void GenerateVSOutputMembers(ShaderCode& object, APIType api_type, u32 texgens,
     DefineOutputMember(object, api_type, qualifier, "float", "clipDist", 0, "SV_ClipDistance", 0);
     DefineOutputMember(object, api_type, qualifier, "float", "clipDist", 1, "SV_ClipDistance", 1);
   }
+  if (host_config.instanced_stereo)
+  {
+    DefineOutputMember(object, api_type, qualifier, "uint", "rendertargetarrayindex", -1,
+                       "SV_RenderTargetArrayIndex");
+  }
 }
 
 void AssignVSOutputMembers(ShaderCode& object, std::string_view a, std::string_view b, u32 texgens,
@@ -159,6 +164,10 @@ void AssignVSOutputMembers(ShaderCode& object, std::string_view a, std::string_v
   {
     object.WriteFmt("\t{}.clipDist0 = {}.clipDist0;\n", a, b);
     object.WriteFmt("\t{}.clipDist1 = {}.clipDist1;\n", a, b);
+  }
+  if (host_config.instanced_stereo)
+  {
+    object.WriteFmt("\t{}.rendertargetarrayindex = {}.rendertargetarrayindex;\n");
   }
 }
 

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -182,7 +182,8 @@ union ShaderHostConfig
     u32 backend_shader_framebuffer_fetch : 1;
     u32 backend_logic_op : 1;
     u32 backend_palette_conversion : 1;
-    u32 pad : 9;
+    u32 instanced_stereo : 1;
+    u32 pad : 8;
   };
 
   static ShaderHostConfig GetCurrent();
@@ -226,6 +227,7 @@ const char* GetInterpolationQualifier(bool msaa, bool ssaa, bool in_glsl_interfa
 
 #define I_POSNORMALMATRIX "cpnmtx"
 #define I_PROJECTION "cproj"
+#define I_PROJECTION_RIGHT "cprojright"
 #define I_MATERIALS "cmtrl"
 #define I_LIGHTS "clights"
 #define I_TEXMATRICES "ctexmtx"
@@ -245,6 +247,7 @@ static const char s_shader_uniforms[] = "\tuint    components;\n"
                                         "\tuint    xfmem_numColorChans;\n"
                                         "\tfloat4 " I_POSNORMALMATRIX "[6];\n"
                                         "\tfloat4 " I_PROJECTION "[4];\n"
+                                        "\tfloat4 " I_PROJECTION_RIGHT "[4];\n"
                                         "\tint4 " I_MATERIALS "[4];\n"
                                         "\tLight " I_LIGHTS "[8];\n"
                                         "\tfloat4 " I_TEXMATRICES "[24];\n"

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -244,7 +244,12 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     out.Write("o.pos = float4(dot(" I_PROJECTION_RIGHT "[0], pos), dot(" I_PROJECTION_RIGHT
               "[1], pos), dot(" I_PROJECTION_RIGHT "[2], pos), dot(" I_PROJECTION_RIGHT "[3], pos));\n");
     out.Write("}\n");
+    out.Write("o.rendertargetarrayindex = instanceid;\n");
   }
+  //if (host_config.instanced_stereo)
+  //{
+    //out.Write("if(instanceid==0) { o.pos.x = 0.5 * o.pos.x - 0.5 * o.pos.w; } else { o.pos.x = 0.5 * o.pos.x + 0.5 * o.pos.w; }\n");
+  //}
 
   out.Write("int4 lacc;\n"
             "float3 ldir, h, cosAttn, distAttn;\n"
@@ -537,10 +542,6 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   }
   else  // D3D
   {
-    if (host_config.instanced_stereo)
-    {
-      out.Write("if(instanceid==0) { o.pos.x = 0.5 * o.pos.x - 0.5 * o.pos.w; } else { o.pos.x = 0.5 * o.pos.x + 0.5 * o.pos.w; }\n");
-    }
     out.Write("return o;\n");
   }
   out.Write("}\n");

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -417,8 +417,8 @@ void VertexShaderManager::SetConstants()
 
     if (xfmem.projection.type == GX_PERSPECTIVE)
     {
-      if (auto session = g_renderer->GetOpenXRSession())
-        corrected_matrix *= session->GetEyeViewMatrix(0, 0, 0);
+      //if (auto session = g_renderer->GetOpenXRSession())
+        //corrected_matrix *= session->GetEyeViewMatrix(0, 0, 0);
 
       if (g_ActiveConfig.bFreeLook)
         corrected_matrix *= g_freelook_camera.GetView();

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -414,6 +414,7 @@ void VertexShaderManager::SetConstants()
              rawProjection[3], rawProjection[4], rawProjection[5]);
 
     auto corrected_matrix = s_viewportCorrection * Common::Matrix44::FromArray(g_fProjectionMatrix);
+    auto corrected_matrix_right = corrected_matrix;
 
     if (xfmem.projection.type == GX_PERSPECTIVE)
     {
@@ -431,6 +432,8 @@ void VertexShaderManager::SetConstants()
         //corrected_matrix *= session->GetHeadMatrix();
         session->ModifyProjectionMatrix(xfmem.projection.type, &corrected_matrix, 0);
         corrected_matrix *= session->GetEyeViewOnlyMatrix(0);
+        session->ModifyProjectionMatrix(xfmem.projection.type, &corrected_matrix_right, 1);
+        corrected_matrix_right *= session->GetEyeViewOnlyMatrix(1);
       }
 
 
@@ -439,6 +442,7 @@ void VertexShaderManager::SetConstants()
     }
 
     memcpy(constants.projection.data(), corrected_matrix.data.data(), 4 * sizeof(float4));
+    memcpy(constants.projection_right.data(), corrected_matrix_right.data.data(), 4 * sizeof(float4));
 
     dirty = true;
   }

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -417,8 +417,9 @@ void VertexShaderManager::SetConstants()
 
     if (xfmem.projection.type == GX_PERSPECTIVE)
     {
-      //if (auto session = g_renderer->GetOpenXRSession())
-        //corrected_matrix *= session->GetEyeViewMatrix(0, 0, 0);
+      if (auto session = g_renderer->GetOpenXRSession())
+        // corrected_matrix *= session->GetEyeViewMatrix(0, 0, 0);
+        corrected_matrix *= session->GetHeadMatrix();
 
       if (g_ActiveConfig.bFreeLook)
         corrected_matrix *= g_freelook_camera.GetView();

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -418,8 +418,21 @@ void VertexShaderManager::SetConstants()
     if (xfmem.projection.type == GX_PERSPECTIVE)
     {
       if (auto session = g_renderer->GetOpenXRSession())
+      {
         // corrected_matrix *= session->GetEyeViewMatrix(0, 0, 0);
-        corrected_matrix *= session->GetHeadMatrix();
+        //float left = (corrected_matrix * Common::Vec4{-1.0f, 0.0f, -1.0f, 1.0f}).x;
+        //float right = (corrected_matrix * Common::Vec4{1.0f, 0.0f, -1.0f, 1.0f}).x;
+        //float up = (corrected_matrix * Common::Vec4{0.0f, 1.0f, -1.0f, 1.0f}).y;
+        //float down = (corrected_matrix * Common::Vec4{0.0f, -1.0f, -1.0f, 1.0f}).y;
+        //float z = (corrected_matrix * Common::Vec4{0.0f, 0.0f, -1.0f, 1.0f}).z;
+        //session->Set3DScreenSize(5.0f * (right - left), 5.0f *(up - down));
+        //session->Set3DScreenZ(z/5.0f);
+        //corrected_matrix = corrected_matrix * session->GetEyeViewOnlyMatrix(0);
+        //corrected_matrix *= session->GetHeadMatrix();
+        session->ModifyProjectionMatrix(xfmem.projection.type, &corrected_matrix, 0);
+        corrected_matrix *= session->GetEyeViewOnlyMatrix(0);
+      }
+
 
       if (g_ActiveConfig.bFreeLook)
         corrected_matrix *= g_freelook_camera.GetView();


### PR DESCRIPTION
Trying to improve the OpenXR support. My code is a bit of a mess, and I can't honestly say I know D3D11 all that well.

Improvements:

* Right eye black is fixed.
* Instanced stereoscopy, to allow for doing tricky math in vertex shader instead of geometry shader
* GX_ORTHOGRAPHIC is projected, so it doesn't cause eye strain in VR.
* Some math fixes

Flaws:

* A bunch of unnecessary code in comments and unneeded functions, when I was experimenting
* GX_ORTHOGRAPHIC is head-locked, so doesn't match geometry.
* Graphical issues caused by offsetting GX_ORTHOGRAPHIC. 
* Head movement results in visible and annoying stutter in headset.
* SMG crashes after spinning (???)
* Not sure I did instanced stereo properly. Seems to rely on geometry shader still, and also potentially a D3D11 extension.
* Still D3D11 only. OpenGL support would be good for a hypothetical Oculus Quest version.

Future possibilities:

* A UI mode (2d? 3d?), to see a screen that reliably has usable UI elements, like a floating theater
* Maybe draw 3 times, and have render array index 0 not project GX_ORTHOGRAPHIC.